### PR TITLE
Fixed path joining problem

### DIFF
--- a/lib/weltmeister.js
+++ b/lib/weltmeister.js
@@ -48,14 +48,14 @@ exports.listen = function(server, options) {
   });
 
   server.post('/lib/weltmeister/api/save.php', function(req, res){
-    var path = req.param('path'),
+    var _path = req.param('path'),
         data = req.param('data');
         
-    if (path && data) {
-      if (/\.js$/.test(path)) {
-        fs.writeFile(root+path, data, function(err){
+    if (_path && data) {
+      if (/\.js$/.test(_path)) {
+        fs.writeFile(path.join(root,_path), data, function(err){
           if (err) {
-            res.send({ error: 2, msg: 'Couldn\'t write to file: '+ path });
+            res.send({ error: 2, msg: 'Couldn\'t write to file: '+ _path });
           } else {
             res.send({ error: 0 });
           }


### PR DESCRIPTION
On windows root + path created an invalid directory, instead used path.join to build a path that will work across platforms.
